### PR TITLE
Update Dockerfile images version to Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use the offical golang image to create a binary.
+# Use the official golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:bookworm as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.21-buster as builder
+FROM golang:bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app
@@ -22,7 +22,7 @@ RUN go build -mod=readonly -v -o golinks
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`golang:1.21-buster` is no longer available on https://hub.docker.com/_/golang.

Fixes:

```
❯ docker build . -t crhuber/golinks:latest
[...]

Sending build context to Docker daemon   33.5MB
Step 1/12 : FROM golang:1.21-buster as builder
manifest for golang:1.21-buster not found: manifest unknown: manifest unknown